### PR TITLE
CA trust directory option

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -21,6 +21,7 @@ awx_isolated_docker_actual_image: "{{ docker_registry }}/{{ docker_registry_name
 awx_webhook_docker_actual_image: "{{ docker_registry }}/{{ docker_registry_namespace }}-webhook:{{ webhook_version }}"
 docker_network_name: "awx"
 docker_network_host_mode: false
+# ca_trust_dir: "/etc/pki/ca-trust" ## Uncomment to bind to host's CA Trust directory.
 
 ### AWX Default Settings
 admin_user: "admin"

--- a/roles/awx/templates/docker-compose.yml.j2
+++ b/roles/awx/templates/docker-compose.yml.j2
@@ -32,6 +32,9 @@ services:
       - "{{ awx_compose_dir }}/nginx.conf:/etc/nginx/nginx.conf:ro"
       - "{{ awx_compose_dir }}/awxweb.pem:/etc/nginx/awxweb.pem:ro"
       - "{{ awx_compose_dir }}/projects:/var/lib/awx/projects:rw"
+{% if ca_trust_dir is defined %}
+      - "{{ ca_trust_dir +':/etc/pki/ca-trust:ro' }}"
+{% endif %}
     environment:
       http_proxy:
       https_proxy:

--- a/roles/awx/templates/docker-compose.yml.j2
+++ b/roles/awx/templates/docker-compose.yml.j2
@@ -33,7 +33,7 @@ services:
       - "{{ awx_compose_dir }}/awxweb.pem:/etc/nginx/awxweb.pem:ro"
       - "{{ awx_compose_dir }}/projects:/var/lib/awx/projects:rw"
 {% if ca_trust_dir is defined %}
-      - "{{ ca_trust_dir +':/etc/pki/ca-trust:ro' }}"
+      - "{{ ca_trust_dir }}:/etc/pki/ca-trust:ro"
 {% endif %}
     environment:
       http_proxy:

--- a/roles/awx/templates/docker-compose.yml.j2
+++ b/roles/awx/templates/docker-compose.yml.j2
@@ -68,6 +68,9 @@ services:
       - "{{ awx_compose_dir }}/environment.sh:/etc/tower/conf.d/environment.sh"
       - "{{ awx_compose_dir }}/redis_socket:/var/run/redis/:rw"
       - "{{ awx_compose_dir }}/projects:/var/lib/awx/projects:rw"
+{% if ca_trust_dir is defined %}
+      - "{{ ca_trust_dir }}:/etc/pki/ca-trust:ro"
+{% endif %}
 {% if awx_isolated_nodes | bool %}
       - "{{ awx_compose_dir }}/ssh_config:/root/.ssh/config"
 {% endif %}


### PR DESCRIPTION
Provide the ability to mount the host's CA Trust Directory onto the docker instance, so as to permit the definition of custom CA trusts needed for secure communications when self-signed or custom signed certificates need to be trusted in an environment.